### PR TITLE
fix: added tolerance to model sum assertion

### DIFF
--- a/R/sig_maths.R
+++ b/R/sig_maths.R
@@ -39,6 +39,9 @@
 #' @export
 sig_combine <- function(signatures, model, format = c("signature", "combined"), verbose=FALSE){
 
+  # Settings
+  tolerance <- 5e-07 # Allows models to sum to anything < 1.000001
+
   # Null replacements
   model <- model %||% numeric(0)
 
@@ -49,7 +52,7 @@ sig_combine <- function(signatures, model, format = c("signature", "combined"), 
 
   model_signatures <- names(model)
   assertions::assert_subset(model_signatures, names(signatures))
-  assertions::assert(sum(model) <= 1, msg = 'Contributions of all signatures in model should add up to <= 1, not [{sum(model)}]')
+  assertions::assert(sum(model) <= 1 + tolerance, msg = 'Contributions of all signatures in model should add up to <= 1, not [{sum(model)}]')
   assertions::assert_no_duplicates(model_signatures)
 
   # Deal with the case that model vector has no length.

--- a/tests/testthat/test-sig_maths.R
+++ b/tests/testthat/test-sig_maths.R
@@ -36,6 +36,9 @@ test_that("sig_combine works", {
   # Fails if model is 0-length numeric vector and format=combined
   expect_error(sig_combine(signatures, model = NULL, format = "combined"), "sensible")
 
+  # Has some tolerance in case signature models add up to 1.000000000000000444089
+  expect_error(sig_combine(signatures, model = c(sig1 = 1.000000000000000444089), format = "signature"), NA)
+
 
 })
 


### PR DESCRIPTION
Set tolerance to  5e-07. Allows models to sum to anything < 1.000001